### PR TITLE
Fix SNDH v2.2 exact song length + add Loop/Continuous/Random play modes

### DIFF
--- a/SndhArchivePlayer/AsyncSndhStream.cpp
+++ b/SndhArchivePlayer/AsyncSndhStream.cpp
@@ -104,19 +104,26 @@ bool AsyncSndhStream::StartSubsong(int subSongId, int durationByDefaultInSec)
 
 	if (info.playerTickCount > 0)
 	{
-		m_lenInSec = info.playerTickCount / info.playerTickRate;
+		// Exact sample count from the SNDH v2.2 "frames" tag, used for playback/WAV end-of-song
+		m_exactSongSamples = info.playerTickCount * info.samplePerTick;
+
+		// Round up to the next whole second for the ImGui slider range
+		m_lenInSec = (info.playerTickCount + info.playerTickRate - 1) / info.playerTickRate;
 		if (m_lenInSec <= 0)
 			m_lenInSec = 1;
 	}
 	else
+	{
+		// No length tag: fall back to the default duration, playing the full buffer
 		m_lenInSec = durationByDefaultInSec;
+		m_exactSongSamples = m_lenInSec * m_replayRate;
+	}
 
 	assert(m_lenInSec >= 1);
-	
+
 	// keep reasonable buffer len
-	assert(uint64_t(m_lenInSec)*uint64_t(m_replayRate)*sizeof(int16_t) < 0x7fffffff);
-	
 	m_audioBufferLen = m_lenInSec * m_replayRate;
+	assert(uint64_t(m_audioBufferLen) * sizeof(int16_t) < 0x7fffffff);
 
 	WAVEFORMATEX	pcmwf;
 	pcmwf.wFormatTag = WAVE_FORMAT_PCM;
@@ -138,7 +145,7 @@ bool AsyncSndhStream::StartSubsong(int subSongId, int durationByDefaultInSec)
 
 	m_waveHeader.dwFlags = 0; // WHDR_BEGINLOOP | WHDR_ENDLOOP;
 	m_waveHeader.lpData = (LPSTR)m_audioBuffer;
-	m_waveHeader.dwBufferLength = m_audioBufferLen * sizeof(int16_t);
+	m_waveHeader.dwBufferLength = m_exactSongSamples * sizeof(int16_t);
 	m_waveHeader.dwBytesRecorded = 0;
 	m_waveHeader.dwUser = 0;
 	m_waveHeader.dwLoops = -1;
@@ -184,11 +191,15 @@ int AsyncSndhStream::GetReplayPosInSec() const
 	MMTIME mmt;
 	mmt.wType = TIME_SAMPLES;
 	if (MMSYSERR_NOERROR != waveOutGetPosition(m_waveOutHandle, &mmt, sizeof(MMTIME)))
-		return 0;
+		return playOffsetInSec;
 
-	const uint32_t posInSample = mmt.u.sample;
-	const uint32_t posInSec = posInSample / m_replayRate;
-	return int(posInSec) + playOffsetInSec;
+	uint32_t posInSample = mmt.u.sample + (playOffsetInSec * m_replayRate);
+
+	// Clip so the reported position never overshoots the exact song length
+	if (posInSample > m_exactSongSamples)
+		posInSample = m_exactSongSamples;
+
+	return int(posInSample / m_replayRate);
 }
 
 void AsyncSndhStream::SetReplayPosInSec(int pos)
@@ -211,7 +222,7 @@ void AsyncSndhStream::SetReplayPosInSec(int pos)
 
 	m_waveHeader.dwFlags = 0; // WHDR_BEGINLOOP | WHDR_ENDLOOP;
 	m_waveHeader.lpData = (LPSTR)(m_audioBuffer + spos);
-	m_waveHeader.dwBufferLength = (m_audioBufferLen - spos)*sizeof(int16_t);
+	m_waveHeader.dwBufferLength = (m_exactSongSamples - spos)*sizeof(int16_t);
 	m_waveHeader.dwBytesRecorded = 0;
 	m_waveHeader.dwUser = 0;
 	m_waveHeader.dwLoops = -1;
@@ -289,7 +300,11 @@ void	AsyncSndhStream::DrawGui(const char* musicName)
 			WavWriter wv;
 			if (wv.Open(sFilename, m_replayRate, 1))
 			{
-				wv.AddAudioData(m_audioBuffer, m_audioBufferLen);
+				uint32_t exactSampleLen = m_exactSongSamples;
+				if (exactSampleLen == 0 || exactSampleLen > m_audioBufferLen)
+					exactSampleLen = m_audioBufferLen;
+
+				wv.AddAudioData(m_audioBuffer, exactSampleLen);
 				wv.Close();
 				m_saved = true;
 			}

--- a/SndhArchivePlayer/AsyncSndhStream.cpp
+++ b/SndhArchivePlayer/AsyncSndhStream.cpp
@@ -12,6 +12,8 @@ AsyncSndhStream::AsyncSndhStream()
 	m_audioDebugBuffer = NULL;
 	m_bLoaded = false;
 	m_asyncInfo.thread = NULL;
+	m_playMode = PlayMode_Single;
+	m_advanceNext = false;
 }
 
 AsyncSndhStream::~AsyncSndhStream()
@@ -81,6 +83,30 @@ void AsyncSndhStream::AsyncWorkerFunction()
 		m_asyncInfo.fillPos += todo;
 
 		m_asyncInfo.progress = (m_asyncInfo.fillPos * 100) / m_audioBufferLen;
+	}
+
+	// Poll for end-of-song here (rather than in DrawGui) so Continuous/Random advance
+	// even while the window is unfocused, where ImGui rendering is throttled.
+	while (!m_asyncInfo.forceQuit)
+	{
+		::Sleep(50);
+
+		const PlayMode mode = m_playMode;
+		if (m_paused || (mode != PlayMode_Continuous && mode != PlayMode_Random))
+			continue;
+
+		MMTIME mmt;
+		mmt.wType = TIME_SAMPLES;
+		if (MMSYSERR_NOERROR != waveOutGetPosition(m_waveOutHandle, &mmt, sizeof(MMTIME)))
+			continue;
+
+		const uint32_t pos = mmt.u.sample + (uint32_t)playOffsetInSec * m_replayRate;
+		if (pos < m_exactSongSamples)
+			continue;
+
+		m_advanceNext = true;
+		m_paused = true;
+		break;
 	}
 }
 
@@ -267,7 +293,7 @@ void	AsyncSndhStream::DrawGui(const char* musicName)
 
 	if (change)
 	{
-		m_paused ^= true;
+		m_paused = !m_paused;
 		Pause(m_paused);
 	}
 	ImGui::SameLine();
@@ -277,11 +303,33 @@ void	AsyncSndhStream::DrawGui(const char* musicName)
 	sprintf_s(sLen, "%d:%02d", m_lenInSec / 60, m_lenInSec % 60);
 	static int pos;
 	pos = GetReplayPosInSec();
+
 	char sPos[64];
 	sprintf_s(sPos, "%d:%02d", pos / 60, pos % 60);
-	if (ImGui::SliderInt(sLen, &pos, 0, m_lenInSec, sPos))
+
+	// Leave room on the right for the length text and the play-mode button
+	ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 110.0f);
+	if (ImGui::SliderInt("##TimeSlider", &pos, 0, m_lenInSec, sPos))
 	{
 		SetReplayPosInSec(pos);
+	}
+	ImGui::PopItemWidth();
+
+	ImGui::SameLine();
+	ImGui::Text("%s", sLen);
+
+	ImGui::SameLine();
+
+	// Cycles Single -> Loop -> Continuous -> Random
+	const char* modeLabels[] = { "[ ]", "[L]", "[C]", "[R]" };
+	if (ImGui::Button(modeLabels[m_playMode]))
+	{
+		m_playMode = static_cast<PlayMode>((m_playMode + 1) % PlayMode_Count);
+	}
+	if (ImGui::IsItemHovered())
+	{
+		const char* tooltips[] = { "Mode: Single Track", "Mode: Loop Current", "Mode: Continuous Play", "Mode: Random Shuffle" };
+		ImGui::SetTooltip("%s", tooltips[m_playMode]);
 	}
 
 	if (musicName)
@@ -313,6 +361,20 @@ void	AsyncSndhStream::DrawGui(const char* musicName)
 	}
 
 	ImGui::EndDisabled();
+
+	// Loop mode only: seamless restart when song ends (Continuous/Random are handled
+	// by the background worker thread so they work even when the app is unfocused)
+	if (m_playMode == PlayMode_Loop && !m_paused)
+	{
+		MMTIME mmt;
+		mmt.wType = TIME_SAMPLES;
+		if (MMSYSERR_NOERROR == waveOutGetPosition(m_waveOutHandle, &mmt, sizeof(MMTIME)))
+		{
+			const uint32_t currentPosInSamples = mmt.u.sample + (playOffsetInSec * m_replayRate);
+			if (currentPosInSamples >= m_exactSongSamples)
+				SetReplayPosInSec(0);
+		}
+	}
 }
 
 const void* AsyncSndhStream::GetRawData(int& fileSize) const

--- a/SndhArchivePlayer/AsyncSndhStream.h
+++ b/SndhArchivePlayer/AsyncSndhStream.h
@@ -18,12 +18,23 @@ public:
 	bool StartSubsong(int subSongId, int durationByDefaultInSec);
 	void Pause(bool pause);
 
+	enum PlayMode
+	{
+		PlayMode_Single = 0,
+		PlayMode_Loop,
+		PlayMode_Continuous,
+		PlayMode_Random,
+		PlayMode_Count
+	};
+
 	int GetReplayPosInSec() const;
 	const int16_t* GetDisplaySampleData(int sampleCount, uint32_t** ppDebugView = NULL) const;
 	int		GetSubsongCount() const;
 	int		GetDefaultSubsong() const;
 	bool	GetSubsongInfo(int subSongId, SndhFile::SubSongInfo& out) const;
 	const void* GetRawData(int& fileSize) const;
+	PlayMode GetPlayMode() const { return m_playMode; }
+	bool ShouldAdvanceNext() { bool ret = m_advanceNext; m_advanceNext = false; return ret; }
 
 	void	DrawGui(const char* musicName);
 
@@ -45,7 +56,7 @@ private:
 
 	bool m_bLoaded;
 	int m_lenInSec;
-	int playOffsetInSec;
+	std::atomic<int> playOffsetInSec;
 	HWAVEOUT	m_waveOutHandle;
 	WAVEHDR		m_waveHeader;
 	int16_t*	m_audioBuffer;
@@ -53,8 +64,10 @@ private:
 	uint32_t 	m_audioBufferLen;
 	uint32_t	m_replayRate;
 	uint32_t	m_exactSongSamples;
-	bool		m_paused;
+	std::atomic<bool> m_paused;
 	bool		m_saved;
+	std::atomic<PlayMode> m_playMode;
+	std::atomic<bool> m_advanceNext;
 
 	AsyncInfo m_asyncInfo;
 };

--- a/SndhArchivePlayer/AsyncSndhStream.h
+++ b/SndhArchivePlayer/AsyncSndhStream.h
@@ -52,6 +52,7 @@ private:
 	uint32_t*	m_audioDebugBuffer;
 	uint32_t 	m_audioBufferLen;
 	uint32_t	m_replayRate;
+	uint32_t	m_exactSongSamples;
 	bool		m_paused;
 	bool		m_saved;
 

--- a/SndhArchivePlayer/SndhArchive.h
+++ b/SndhArchivePlayer/SndhArchive.h
@@ -2,6 +2,8 @@
 #include <stdint.h>
 #include <thread>
 #include <atomic>
+#include <random>
+#include <ctime>
 #include "imgui_internal.h"
 #include "extern/zip/src/zip.h"
 #include "jobSystem.h"
@@ -25,6 +27,56 @@ public:
 	void	ImGuiDraw(SndhArchivePlayer& player);
 	bool	IsOpen() const { return m_zipArchive != NULL; }
 	bool	IsOpening() const { return m_asyncBrowse; }
+
+	// Returns the zipIndex following currentZipIndex in the filtered list, or -1 if last/not found
+	int GetNextFilteredZipIndex(int currentZipIndex) const
+	{
+		for (int i = 0; i < m_filterdSize - 1; ++i)
+		{
+			if (m_filteredList[i].zipIndex == currentZipIndex)
+				return m_filteredList[i + 1].zipIndex;
+		}
+		return -1;
+	}
+
+	// Returns the zipIndex preceding currentZipIndex in the filtered list, or -1 if first/not found
+	int GetPrevFilteredZipIndex(int currentZipIndex) const
+	{
+		for (int i = 1; i < m_filterdSize; ++i)
+		{
+			if (m_filteredList[i].zipIndex == currentZipIndex)
+				return m_filteredList[i - 1].zipIndex;
+		}
+		return -1;
+	}
+
+	// Picks a random track (and random subsong, if it has several) from the filtered list
+	void GetRandomFilteredSong(int& outZipIndex, int& outSubsong) const
+	{
+		if (m_filterdSize <= 0)
+		{
+			outZipIndex = -1;
+			outSubsong = 1;
+			return;
+		}
+
+		static std::mt19937 rng(static_cast<unsigned int>(std::time(nullptr)));
+		std::uniform_int_distribution<int> fileDist(0, m_filterdSize - 1);
+		const int randomRow = fileDist(rng);
+
+		outZipIndex = m_filteredList[randomRow].zipIndex;
+
+		const int subsongCount = m_filteredList[randomRow].subsongCount;
+		if (subsongCount > 1)
+		{
+			std::uniform_int_distribution<int> subDist(1, subsongCount);
+			outSubsong = subDist(rng);
+		}
+		else
+		{
+			outSubsong = 1;
+		}
+	}
 
 private:
 	struct PlayListItem

--- a/SndhArchivePlayer/SndhArchivePlayer.cpp
+++ b/SndhArchivePlayer/SndhArchivePlayer.cpp
@@ -72,6 +72,8 @@ void	SndhArchivePlayer::PlayZipEntry(SndhArchive& sndhArchive, int zipIndex)
 	{
 		if (0 == zip_entry_openbyindex(zipArchive, zipIndex))
 		{
+			m_currentZipIndex = zipIndex;
+
 			size_t size = zip_entry_size(zipArchive);
 			void* unpack = calloc(1, size);
 
@@ -370,7 +372,9 @@ void	SndhArchivePlayer::UpdateImGui()
 				ImGui::TableNextColumn();
 				ImGui::TextUnformatted("Sub-tune:");
 				ImGui::TableNextColumn();
+
 				int dir = 0;
+
 				if (ImGui::ArrowButton("prev", ImGuiDir_Left))
 					dir = -1;
 				ImGui::SameLine();
@@ -382,17 +386,87 @@ void	SndhArchivePlayer::UpdateImGui()
 				ImGui::SameLine();
 				ImGui::Text("(%d Hz)", info.playerTickRate);
 
+				// Continuous/Random signaled that the current song has ended
+				if (m_sndh.ShouldAdvanceNext())
+					dir = 1;
+
+				// Set when we need to load a different archive entry rather than
+				// just switching sub-song within the currently loaded file
+				int pendingNextZipIndex = -1;
+				int targetSubsongOnLoad = 1;
+
 				if (dir)
 				{
 					int newSubsong = m_currentSubSong + dir;
-					if (newSubsong < 1) newSubsong = 1;
-					if (newSubsong > m_sndh.GetSubsongCount())
-						newSubsong = m_sndh.GetSubsongCount();
-					if (newSubsong != m_currentSubSong)
+
+					// Random mode always shuffles to a new file when moving forward,
+					// whether triggered by the user or by natural end-of-song
+					const bool forceRandomFileSkip = (dir == 1 && m_sndh.GetPlayMode() == AsyncSndhStream::PlayMode_Random);
+
+					if (newSubsong < 1)
+					{
+						int prevZipIndex = gArchive.GetPrevFilteredZipIndex(m_currentZipIndex);
+						if (prevZipIndex != -1)
+							pendingNextZipIndex = prevZipIndex;
+						else
+							newSubsong = 1;
+					}
+					else if (newSubsong > m_sndh.GetSubsongCount() || forceRandomFileSkip)
+					{
+						if (m_sndh.GetPlayMode() == AsyncSndhStream::PlayMode_Random)
+						{
+							int randZipIdx = -1;
+							int randSubsongIdx = 1;
+							gArchive.GetRandomFilteredSong(randZipIdx, randSubsongIdx);
+
+							if (randZipIdx != -1)
+							{
+								pendingNextZipIndex = randZipIdx;
+								targetSubsongOnLoad = randSubsongIdx;
+							}
+							else
+							{
+								newSubsong = m_sndh.GetSubsongCount();
+							}
+						}
+						else
+						{
+							int nextZipIndex = gArchive.GetNextFilteredZipIndex(m_currentZipIndex);
+							if (nextZipIndex != -1)
+							{
+								pendingNextZipIndex = nextZipIndex;
+								targetSubsongOnLoad = 1;
+							}
+							else
+							{
+								newSubsong = m_sndh.GetSubsongCount();
+							}
+						}
+					}
+
+					// Only switch sub-songs inside the current file if we aren't swapping physical files
+					if (pendingNextZipIndex == -1 && newSubsong != m_currentSubSong)
+					{
 						StartSubsong(newSubsong);
+					}
 				}
+
 				ImGui::EndTable();
-				m_sndh.DrawGui(info.musicName);
+
+				if (pendingNextZipIndex == -1)
+				{
+					m_sndh.DrawGui(info.musicName);
+				}
+				else
+				{
+					PlayZipEntry(gArchive, pendingNextZipIndex);
+
+					// A random pick may target a specific sub-song rather than the default one
+					if (targetSubsongOnLoad > 1)
+					{
+						StartSubsong(targetSubsongOnLoad);
+					}
+				}
 			}
 		}
 

--- a/SndhArchivePlayer/SndhArchivePlayer.h
+++ b/SndhArchivePlayer/SndhArchivePlayer.h
@@ -29,10 +29,11 @@ public:
 private:
 	bool	StartSubsong(int subsong);
 	void	DrawPlayList();
-	bool show_demo_window = false;
-	bool show_another_window = false;
+	bool	show_demo_window = false;
+	bool	show_another_window = false;
 
 	AsyncSndhStream	m_sndh;
-	int			m_currentSubSong;
+	int		m_currentSubSong;
+	int		m_currentZipIndex = -1;
 
 };


### PR DESCRIPTION
## Summary
- Fix song length/end-of-song detection to use the exact sample count from the SNDH v2.2 "frames" tag instead of truncating to whole seconds, so playback (and WAV export) stops exactly where the song ends.
- Add a 4-state play mode button (Single / Loop / Continuous / Random):
  - Loop restarts the current sub-song gaplessly at its exact end sample.
  - Continuous advances through sub-songs, then to the next file in the current filtered playlist.
  - Random shuffles to a random file (and sub-song) from the current filtered playlist.
- End-of-song detection for Continuous/Random runs in the audio worker thread so it keeps advancing even when the window is unfocused (ImGui updates are throttled in the background).

Two commits, reviewable separately:
1. Exact song length fix (self-contained).
2. Play modes feature (depends on commit 1's exact sample tracking).

## Test plan
- [ ] Load an SNDH v2.2 file with a "frames" length tag, confirm playback/WAV export stop exactly at song end (Good candidate: Wings of Death STE songs by Mad Max should loop nicely)
- [ ] Loop mode: confirm gapless restart on a multi-second track
- [ ] Continuous mode: confirm advance across sub-songs, then across files in the filtered playlist
- [ ] Random mode: confirm shuffle both via manual "next" and natural song end
- [ ] Confirm Continuous/Random still advance while the app window is unfocused
